### PR TITLE
devices: Fix reconfigure devices

### DIFF
--- a/guh/parameters.py
+++ b/guh/parameters.py
@@ -69,13 +69,13 @@ def edit_params(currentDeviceParams, paramTypes):
         if 'readOnly' in paramType:
             if paramType['readOnly'] == True:
                 print "--------------------------------------------------------"
-                print "\nThe param \"%s\" is not writable! (current = \"%s\")\n" %(paramType['name'], get_param_value(paramType['name'], currentDeviceParams))
+                print "\nThe param \"%s\" is not writable! (current = \"%s\")\n" %(paramType['name'], get_param_value(paramType['id'], currentDeviceParams))
                 raw_input("\nPress \"enter\" to continue...\n")
                 print "--------------------------------------------------------"
                 continue
         param = {}
         if any("allowedValues" in item for item in paramType):
-            title = "Please select one of following allowed values: (current = \"%s\")" % (get_param_value(paramType['name'], currentDeviceParams))
+            title = "Please select one of following allowed values: (current = \"%s\")" % (get_param_value(paramType['id'], currentDeviceParams))
             selection = guh.get_selection(title, paramType['allowedValues'])
             if selection == None:
                 return None
@@ -87,7 +87,7 @@ def edit_params(currentDeviceParams, paramTypes):
             # make bool selectable to make shore they are "true" or "false"
             if paramType['type'] == "Bool":
                 boolTypes = ["true","false"]
-                selectionString = "Please enter value (currently: \"%s\") for parameter \"%s\" (type: %s): " % (get_param_value(paramType['name'], currentDeviceParams), paramType['name'], paramType['type'])
+                selectionString = "Please enter value (currently: \"%s\") for parameter \"%s\" (type: %s): " % (get_param_value(paramType['id'], currentDeviceParams), paramType['name'], paramType['type'])
                 selection = guh.get_selection(selectionString, boolTypes)
                 if selection == None:
                     return None
@@ -95,7 +95,7 @@ def edit_params(currentDeviceParams, paramTypes):
                 param['paramTypeId'] = paramType['id']
                 param['value'] = paramValue
             else:
-                paramValue = raw_input("Please enter value (currently: \"%s\") for parameter \"%s\" (type: %s): " % (get_param_value(paramType['name'], currentDeviceParams), paramType['name'], paramType['type']))
+                paramValue = raw_input("Please enter value (currently: \"%s\") for parameter \"%s\" (type: %s): " % (get_param_value(paramType['id'], currentDeviceParams), paramType['name'], paramType['type']))
                 param['paramTypeId'] = paramType['id']
                 param['value'] = paramValue
         params.append(param)
@@ -110,7 +110,7 @@ def getParamName(paramTypeId, paramTypes):
 
 def get_param_value(paramTypeId, params):
     for param in params:
-        if param['id'] == paramTypeId:
+        if param['paramTypeId'] == paramTypeId:
             return param['value']
     return None
 


### PR DESCRIPTION
Finally my first PR to guh :-)

Fixes the following error and allows to reconfigure devices again.

Traceback (most recent call last):
  File "/usr/bin/guh-cli", line 56, in <module>
    mainmenu.start(args.host, args.port)
  File "/usr/lib/python2.7/dist-packages/guh/mainmenu.py", line 830, in start
    processmenu(menu_data)
  File "/usr/lib/python2.7/dist-packages/guh/mainmenu.py", line 916, in processmenu
    processmenu(menu['options'][getin], menu)
  File "/usr/lib/python2.7/dist-packages/guh/mainmenu.py", line 905, in processmenu
    methodCall()
  File "/usr/lib/python2.7/dist-packages/guh/mainmenu.py", line 506, in method_reconfigure_device
    devices.reconfigure_device()
  File "/usr/lib/python2.7/dist-packages/guh/devices.py", line 197, in reconfigure_device
    newDeviceParams = parameters.edit_params(currentDeviceParams, deviceParamTypes)
  File "/usr/lib/python2.7/dist-packages/guh/parameters.py", line 98, in edit_params
    paramValue = raw_input("Please enter value (currently: \"%s\") for parameter \"%s\" (type: %s): " % (get_param_value(paramType['name'], currentDeviceParams), paramType['name'], paramType['type']))
  File "/usr/lib/python2.7/dist-packages/guh/parameters.py", line 113, in get_param_value
    if param['id'] == paramTypeId:
KeyError: 'id'